### PR TITLE
duplicate template as an api function

### DIFF
--- a/classes/event/template_created.php
+++ b/classes/event/template_created.php
@@ -70,7 +70,7 @@ class template_created extends \core\event\base {
      * @param \stdClass $template
      * @return template_created
      */
-    public static function create_from_template(\stdClass $template) {
+    public static function create_from_template(\stdClass $template) : template_created {
         $data = array(
             'context' => \context::instance_by_id($template->contextid),
             'objectid' => $template->id,

--- a/classes/event/template_deleted.php
+++ b/classes/event/template_deleted.php
@@ -77,9 +77,9 @@ class template_deleted extends \core\event\base {
      * Create instance of event.
      *
      * @param \stdClass $template
-     * @return template_created
+     * @return template_deleted
      */
-    public static function create_from_template(\stdClass $template) {
+    public static function create_from_template(\stdClass $template) : template_deleted {
         $data = array(
             'context' => \context::instance_by_id($template->contextid),
             'objectid' => $template->id,

--- a/classes/event/template_updated.php
+++ b/classes/event/template_updated.php
@@ -77,7 +77,7 @@ class template_updated extends \core\event\base {
      * Create instance of event.
      *
      * @param \stdClass $template
-     * @return template_created
+     * @return template_updated
      */
     public static function create_from_template(\stdClass $template): template_updated {
         $data = array(

--- a/classes/template.php
+++ b/classes/template.php
@@ -362,6 +362,22 @@ class template {
     }
 
     /**
+     * Duplicates the template into a new one
+     *
+     * @return template
+     */
+    public function duplicate() {
+        $name = $this->get_name() . ' (' . strtolower(get_string('duplicate', 'tool_certificate')) . ')';
+        $contextid = $this->get_contextid();
+        $newtemplate = self::create($name, $contextid);
+
+        // Copy the data to the new template.
+        $this->copy_to_template($newtemplate->get_id());
+
+        return $newtemplate;
+    }
+
+    /**
      * Handles moving an item on a template.
      *
      * @param string $itemname the item we are moving

--- a/manage_templates.php
+++ b/manage_templates.php
@@ -103,16 +103,8 @@ if ($tid) {
                 exit();
             }
 
-            // Create another template to copy the data to.
-            $newtemplate = new \stdClass();
-            $newtemplate->name = $template->get_name() . ' (' . strtolower(get_string('duplicate', 'tool_certificate')) . ')';
-            $newtemplate->contextid = $template->get_contextid();
-            $newtemplate->timecreated = time();
-            $newtemplate->timemodified = $newtemplate->timecreated;
-            $newtemplateid = $DB->insert_record('tool_certificate_templates', $newtemplate);
-
             // Copy the data to the new template.
-            $template->copy_to_template($newtemplateid);
+            $template->duplicate();
 
             // Redirect back to the manage templates page.
             redirect(new moodle_url('/admin/tool/certificate/manage_templates.php'));


### PR DESCRIPTION
First I noticed that event is not triggered when template is duplicated but then I realised that it actually should be an API method and use "create" function inside it