### PR TITLE
WPOS-114 - Support user context

### DIFF
--- a/classes/permission.php
+++ b/classes/permission.php
@@ -235,7 +235,7 @@ class permission {
             $context = \context_system::instance();
         }
         if ($context->contextlevel != CONTEXT_SYSTEM && $context->contextlevel != CONTEXT_COURSECAT
-                && $context->contextlevel != CONTEXT_COURSE) {
+                && $context->contextlevel != CONTEXT_COURSE && $context->contextlevel != CONTEXT_USER) {
             return false;
         }
         if (class_exists('\\tool_organisation\\organisation')) {

--- a/lib.php
+++ b/lib.php
@@ -112,7 +112,7 @@ function tool_certificate_pluginfile($course, $cm, $context, $filearea, $args, $
  */
 function tool_certificate_myprofile_navigation(core_user\output\myprofile\tree $tree, $user, $iscurrentuser, $course) {
     global $USER;
-    if (permission::can_view_list($user->id)) {
+    if (permission::can_view_list($user->id, \context_user::instance($user->id))) {
         if ($USER->id == $user->id) {
             $link = get_string('mycertificates', 'tool_certificate');
         } else {

--- a/my.php
+++ b/my.php
@@ -36,7 +36,7 @@ require_login();
 
 // Check that we have a valid user.
 $user = \core_user::get_user($userid ?: $USER->id, '*', MUST_EXIST);
-if (!\tool_certificate\permission::can_view_list($user->id)) {
+if (!\tool_certificate\permission::can_view_list($user->id, \context_user::instance($user->id))) {
     throw new \required_capability_exception(context_system::instance(), 'tool/certificate:viewallcertificates',
         'nopermission', 'error');
 }


### PR DESCRIPTION
This is useful for Moodle sites where users have roles assigned on other user profiles (context) so they can manage or tutor those users and view them on the mentees block.