### PR TITLE
Allow overriding name on issued certificates

### DIFF
--- a/classes/certificate.php
+++ b/classes/certificate.php
@@ -110,7 +110,7 @@ class certificate {
         $userfields = self::get_extra_user_fields($context);
 
         $sql = "SELECT ci.id as issueid, ci.code, ci.emailed, ci.timecreated, ci.userid, ci.templateid, ci.expires,
-                       t.name, ci.data, {$userfields}
+                       COALESCE(ci.name, t.name) AS name, ci.data, {$userfields}
                   FROM {tool_certificate_templates} t
                   JOIN {tool_certificate_issues} ci
                     ON (ci.templateid = t.id)
@@ -245,7 +245,7 @@ class certificate {
         $userfields = self::get_extra_user_fields($context);
 
         $sql = "SELECT ci.id as issueid, ci.code, ci.emailed, ci.timecreated, ci.userid, ci.templateid, ci.expires,
-                       t.name, ci.courseid, ci.archived, $userfields,
+                       COALESCE(ci.name, t.name) AS name, ci.courseid, ci.archived, $userfields,
                   CASE WHEN ci.expires > 0  AND ci.expires < :now THEN 0
                   ELSE 1
                   END AS status
@@ -317,7 +317,7 @@ class certificate {
         }
 
         $sql = "SELECT ci.id, ci.expires, ci.code, ci.timecreated, ci.userid, ci.courseid,
-                       t.id as templateid, t.contextid, t.name
+                       t.id as templateid, t.contextid, COALESCE(ci.name, t.name) AS name
                   FROM {tool_certificate_templates} t
             INNER JOIN {tool_certificate_issues} ci
                     ON t.id = ci.templateid
@@ -388,7 +388,8 @@ class certificate {
         $sql = "SELECT ci.id, ci.templateid, ci.code, ci.emailed, ci.timecreated,
                        ci.expires, ci.data, ci.component, ci.courseid,
                        ci.userid, ci.archived,
-                       t.name as certificatename,
+                       t.name AS certificatename,
+                       ci.name,
                        t.contextid
                   FROM {tool_certificate_templates} t
                   JOIN {tool_certificate_issues} ci

--- a/classes/output/verify_certificate_result.php
+++ b/classes/output/verify_certificate_result.php
@@ -90,7 +90,7 @@ class verify_certificate_result implements templatable, renderable {
         $this->viewurl = template::view_url($issue->code);
         $this->userprofileurl = new \moodle_url('/user/view.php', ['id' => $issue->userid]);
         $this->userfullname = @json_decode($issue->data, true)['userfullname'];
-        $this->certificatename = $issue->certificatename;
+        $this->certificatename = $issue->name ?? $issue->certificatename;
         $strftimedatetime = get_string("strftimedatetime", "langconfig");
         $this->timecreated = userdate($issue->timecreated, $strftimedatetime);
         $this->expires = $issue->expires > 0

--- a/classes/reportbuilder/local/entities/issue.php
+++ b/classes/reportbuilder/local/entities/issue.php
@@ -120,6 +120,17 @@ class issue extends base {
 
         // Column certificate issue timecreated.
         $columns[] = (new column(
+            'name',
+            new lang_string('issuename', 'tool_certificate'),
+            $this->get_entity_name()
+        ))
+            ->add_joins($this->get_joins())
+            ->set_type(column::TYPE_TEXT)
+            ->set_is_sortable(true)
+            ->add_field("{$certificateissuealias}.name");
+
+        // Column certificate issue timecreated.
+        $columns[] = (new column(
             'timecreated',
             new lang_string('issueddate', 'tool_certificate'),
             $this->get_entity_name()

--- a/classes/template.php
+++ b/classes/template.php
@@ -819,6 +819,8 @@ class template {
         $userfullname = fullname($user, true);
         $mycertificatesurl = new moodle_url('/admin/tool/certificate/my.php');
         $subject = get_string('notificationsubjectcertificateissued', 'tool_certificate');
+        $name = $issue->name ?? $this->get_name();
+        $subject = "$name - $subject";
         $fullmessage = get_string(
             'notificationmsgcertificateissued',
             'tool_certificate',

--- a/db/install.xml
+++ b/db/install.xml
@@ -23,6 +23,7 @@
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="templateid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="code" TYPE="char" LENGTH="40" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="emailed" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -247,5 +247,18 @@ function xmldb_tool_certificate_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2023071300, 'tool', 'certificate');
     }
 
+    if ($oldversion < 2024061000) {
+        $table = new xmldb_table('tool_certificate_issues');
+        $field = new xmldb_field('name', XMLDB_TYPE_CHAR, '255');
+
+        // Conditionally add field name to tool_certificate_issues.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Certificate savepoint reached.
+        upgrade_plugin_savepoint(true, 2024061000, 'tool', 'certificate');
+    }
+
     return true;
 }

--- a/lang/en/tool_certificate.php
+++ b/lang/en/tool_certificate.php
@@ -121,6 +121,7 @@ $string['issuedcertificates'] = 'Issued certificates';
 $string['issueddate'] = 'Date issued';
 $string['issuelang'] = 'Issue certificates in user language';
 $string['issuelangdesc'] = 'On multi-lingual sites when user language is different from the site language the certificates will be generated in the user\'s language, otherwise all certificates will be generated in the site default language.';
+$string['issuename'] = 'Name (issued)';
 $string['issuenotallowed'] = 'You are not allowed to issue certificates from this template.';
 $string['issueormangenotallowed'] = 'You are not allowed to issue certificates from or manage this template.';
 $string['leftmargin'] = 'Left margin';

--- a/tests/certificate_test.php
+++ b/tests/certificate_test.php
@@ -357,6 +357,23 @@ final class certificate_test extends advanced_testcase {
     }
 
     /**
+     * Verify a certificate issued with a custom name uses that custom name
+     */
+    public function test_can_set_certificate_name(): void {
+        $testname = 'Test Certificate 1';
+
+        $this->setAdminUser();
+        $certificate1 = $this->get_generator()->create_template((object)['name' => 'Certificate 1']);
+        $user1 = $this->getDataGenerator()->create_user();
+        $certificate1->issue_certificate($user1->id, null, [], 'tool_certificate', null, $testname);
+
+        $issues = certificate::get_issues_for_template($certificate1->get_id(), 0, 100);
+        $this->assertCount(1, $issues);
+        $issue = reset($issues);
+        $this->assertEquals($testname, $issue->name);
+    }
+
+    /**
      * Test generate code.
      */
     public function test_generate_code(): void {

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component    = 'tool_certificate';
 $plugin->release      = '4.4';
-$plugin->version      = 2024052100;
+$plugin->version      = 2024061000;
 $plugin->requires     = 2022041900.00;
 $plugin->maturity     = MATURITY_STABLE;
 $plugin->supported    = [400, 404];


### PR DESCRIPTION
- Useful for when a common template is used across multiple certification paths
- Overrides the certificate name when listing certificates to user
- Is used for PDF document names