### PR TITLE
Add hook for certificate element classes discovery

### DIFF
--- a/classes/element.php
+++ b/classes/element.php
@@ -69,18 +69,19 @@ abstract class element {
      * Helper method to create an instance from persistent
      *
      * @param \tool_certificate\persistent\element $persistent
-     * @return element
+     * @return element|null
      */
     protected static function instance_from_persistent(\tool_certificate\persistent\element $persistent): ?element {
-        // Get the class name.
-        $classname = '\\certificateelement_' . $persistent->get('element') . '\\element';
+        $elementclasses = element_helper::get_element_classes();
 
-        // Ensure the necessary class exists.
-        if (!class_exists($classname) || !is_subclass_of($classname, self::class)) {
+        $shortname = $persistent->get('element');
+        if (!isset($elementclasses[$shortname])) {
             return null;
         }
 
-        /** @var self $el */
+        /** @var class-string<element> $classname */
+        $classname = $elementclasses[$shortname];
+
         $el = new $classname($persistent);
         $el->persistent = $persistent;
         return $el;

--- a/classes/hook/element_classes.php
+++ b/classes/hook/element_classes.php
@@ -1,0 +1,76 @@
+<?php
+// This file is part of the tool_certificate plugin for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_certificate\hook;
+
+/**
+ * Certification element classes discovery hook.
+ *
+ * @package     tool_certificate
+ * @copyright   2024 Petr Skoda
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class element_classes implements \core\hook\described_hook {
+    /**
+     * @var array<string, class-string<\tool_certificate\element>>
+     */
+    protected $classes = [];
+
+    /**
+     * Add known enabled element class.
+     *
+     * @param string $shortname name of certificateelement sub-plugin or other unique name
+     * @param string $classname \tool_certificate\element class
+     */
+    public function add_class(string $shortname, string $classname): void {
+        if (!class_exists($classname) || !is_subclass_of($classname, \tool_certificate\element::class)) {
+            debugging('Invalid certificate element class: ' . $classname, DEBUG_DEVELOPER);
+            return;
+        }
+        if (isset($this->classes[$shortname])) {
+            debugging('Duplicate certificate element short name detected: ' . $shortname, DEBUG_DEVELOPER);
+            // Override previous in case admins forgot to uninstall element add-on.
+        }
+        $this->classes[$shortname] = $classname;
+    }
+
+    /**
+     * Returns known enabled element classes indexed with their short names.
+     *
+     * @return array<string, class-string<\tool_certificate\element>>
+     */
+    public function get_classes(): array {
+        return $this->classes;
+    }
+
+    /**
+     * Hook description.
+     *
+     * @return string
+     */
+    public static function get_hook_description(): string {
+        return 'Certificate element class discovery';
+    }
+
+    /**
+     * Hook tags.
+     *
+     * @return array
+     */
+    public static function get_hook_tags(): array {
+        return [];
+    }
+}

--- a/classes/output/element.php
+++ b/classes/output/element.php
@@ -89,11 +89,10 @@ class element extends persistent_exporter {
      */
     protected function get_other_values(\renderer_base $output): array {
         $element = $this->get_element();
-        $pluginname = 'certificateelement_' . $this->persistent->get('element');
         return [
             'displayname' => $element->get_display_name(),
             'editablename' => $element->get_inplace_editable()->export_for_template($output),
-            'elementtype' => get_string('pluginname', $pluginname),
+            'elementtype' => $element::get_element_type_name(),
             'movetitle' => get_string('changeelementsequence', 'tool_certificate'),
             'icon' => $output->render($this->get_element()->get_element_type_image(true)),
             'html' => $this->get_element()->render_html(),


### PR DESCRIPTION
Hi Marina,

I am maintaining a few certificate elements which is a bit annoying because Modole plugin database does not even support this subplugin type (last time I checked).

So I was thinking if it would be possible to add support for discovery of additional elements from other plugins via hooks, turns out it was pretty simple, see the small patch.

What do you think?