### PR TITLE
[Moodle 5.0] Remove deprecated report builder default table alias

### DIFF
--- a/classes/reportbuilder/local/entities/issue.php
+++ b/classes/reportbuilder/local/entities/issue.php
@@ -40,21 +40,14 @@ use tool_certificate\permission;
 class issue extends base {
 
     /**
-     * Database tables that this entity uses and their default aliases
-     *
-     * @return array
-     */
-    protected function get_default_table_aliases(): array {
-        return ['tool_certificate_issues' => 'tci'];
-    }
-
-    /**
      * Database tables that this entity uses
      *
      * @return string[]
      */
     protected function get_default_tables(): array {
-        return array_keys($this->get_default_table_aliases());
+        return [
+            'tool_certificate_issues',
+        ];
     }
 
     /**

--- a/classes/reportbuilder/local/entities/template.php
+++ b/classes/reportbuilder/local/entities/template.php
@@ -40,23 +40,14 @@ use tool_certificate\template as certificate_template;
 class template extends base {
 
     /**
-     * Database tables that this entity uses and their default aliases
-     *
-     * @return array
-     */
-    protected function get_default_table_aliases(): array {
-        return [
-            'tool_certificate_templates' => 'tct',
-        ];
-    }
-
-    /**
      * Database tables that this entity uses
      *
      * @return string[]
      */
     protected function get_default_tables(): array {
-        return array_keys($this->get_default_table_aliases());
+        return [
+            'tool_certificate_templates',
+        ];
     }
 
     /**


### PR DESCRIPTION
When installed on Moodle 5.0, unit tests fail on `Fatal error: Declaration of tool_certificate\reportbuilder\local\entities\issue::get_default_table_aliases(): array must be compatible with core_reportbuilder\local\entities\base::get_default_table_aliases(): void `

It is a consequence of [this change](https://tracker.moodle.org/browse/MDL-80430). I've updated the plugin code to align it with the updated Moodle code.