### PR TITLE
[Moodle 5.0]  Implement new subplugintypes object in subplugins.json

### DIFF
--- a/db/subplugins.json
+++ b/db/subplugins.json
@@ -1,4 +1,7 @@
 {
+  "subplugintypes": {
+    "certificateelement": "element"
+  },
   "plugintypes": {
     "certificateelement": "admin\/tool\/certificate\/element"
   }


### PR DESCRIPTION
When installed on Moodle 5.0, unit tests fail on PHPUnitFrameworkException: No subplugintypes defined in /builds/elearning/local/moodle-local/admin/tool/certificate/db/subplugins.json. Falling back to deprecated plugintypes value. See MDL-83705 for further information.

It is a consequence of [this change](https://tracker.moodle.org/browse/MDL-83705). I've updated the plugin code to align it with the updated Moodle code.